### PR TITLE
Added anchor to LinkAttributes

### DIFF
--- a/packages/storyblok-rich-text-types/src/nodes/mark.ts
+++ b/packages/storyblok-rich-text-types/src/nodes/mark.ts
@@ -42,6 +42,7 @@ export interface LinkAttributes {
   uuid: string | null;
   target: LinkTarget;
   linktype: LinkType;
+  anchor?: string;
 }
 
 export interface LinkNode extends MarkNode {


### PR DESCRIPTION
There is an anchor prop missing from the LinkAttributes type. Don't know if it should be string | null type or optional string type.

Would be great so I don't get ts errors in my code 🙃 

![image](https://user-images.githubusercontent.com/68996622/119822780-f4e25e00-beeb-11eb-8885-c658c022c0d1.png)
